### PR TITLE
Add instructions for Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,14 @@ The set up for each cloud environment is located in a seperate directory. For us
 ## Keylime on Google Cloud
 Ansible role to deploy a Fedora 35 instance on the Google Cloud Platform with [Keylime](https://github.com/keylime/keylime) and the [rust agent](https://github.com/keylime/rust-keylime) against a Virtualized TPM.
 
-See the [README](https://github.com/keylime/keylime-cloud-environments/keylime-ansible-gcp/README.md) for further information on set up and usage. 
+See the [README](https://github.com/keylime/keylime-cloud-environments/tree/main/keylime-ansible-gcp) for further information on set up and usage. 
+
+## Keylime on AWS
+Ansible role to deploy a Fedora 35 instance on AWS with [Keylime](https://github.com/keylime/keylime) and the [rust agent](https://github.com/keylime/rust-keylime) against a Virtualized TPM.
+This role is currently in developement. 
+
+See the [README](https://github.com/keylime/keylime-cloud-environments/tree/main/keylime-ansible-aws) for further information.
+
+## Keylime on Azure
+The ansible collection for Azure does not yet have the functionality to create a VM with 'Trusted Launch' (enable the vTPM). Manual set up instructions can be found in the [README]((https://github.com/keylime/keylime-cloud-environments/tree/main/keylime-azure) until making an ansible role is possible. 
+ 

--- a/keylime-azure/README.md
+++ b/keylime-azure/README.md
@@ -1,0 +1,21 @@
+# Keylime for Azure
+These instructions decribe the steps to deploy a VM with vTPM on Azure. 
+
+For details on using Keylime, please consult the
+[project documentation](https://keylime-docs.readthedocs.io/en/latest/).
+
+For details on the Rust agent, please consult the [repository](https://github.com/keylime/rust-keylime).
+
+## Manual Set Up 
+### Instance with vTPM
+1. Create a RHEL 8.5 x86_64 instances with Security Type: ”Trusted Launch", this will enable the vTPM 
+2. The root volume defaults to 2GB no matter the size of the disk, it needs to be extended for Keylime installation. \
+`# sudo lvextend -L+#G  /dev/rootvg/rootlv`  
+Where `#` is the number of GB to be added 
+3. Reboot the machine 
+4. Use `lsblk` and `df -h` to check that it was extended
+
+## Future Work 
+### Ansible Playbook 
+This set up has not been automated as the ansible collection for Azure does not provide support for `Trusted Launch`. Once support for this is added, then the development of an ansible playbook becomes possible.
+


### PR DESCRIPTION
Add manual set up instructions for setting up an Azure VM with the vTPM enabled. This set up has not been automated as the ansible collection for Azure does not provide support for Trusted Launch. Once support for this is added, then the development of an ansible playbook becomes possible. @lkatalin 